### PR TITLE
mettre les attachable_options du documentation_pages avant de affiche…

### DIFF
--- a/app/controllers/documentation_controller.rb
+++ b/app/controllers/documentation_controller.rb
@@ -3,6 +3,7 @@ require_dependency 'wiki_controller'
 class DocumentationController < WikiController
 
   append_before_action :render_403_if_wiki, :only => [:show, :protect, :history, :diff, :annotate, :export, :add_attachment]
+  append_before_action :set_attachable_options, :only => [:show]
 
   # display a page (in editing mode if it doesn't exist)
   def show
@@ -226,6 +227,12 @@ class DocumentationController < WikiController
 
   def render_403_if_wiki
     return render_403 if @page&.persisted? && @page.wiki_page?
+  end
+
+  def set_attachable_options
+    @page.class.attachable_options[:view_permission] = "view_documentation_pages".to_sym
+    @page.class.attachable_options[:edit_permission] = "edit_documentation_pages".to_sym
+    @page.class.attachable_options[:delete_permission] = "edit_documentation_pages".to_sym
   end
 
 end

--- a/spec/system/documentation_spec.rb
+++ b/spec/system/documentation_spec.rb
@@ -102,4 +102,26 @@ content}
     expect(page).to have_selector("h2", text: "New page not persisted") # New page, OK
   end
 
+  # Before this correction, the user cannot see the image, delete it, or modify it
+  it "Should show both icons of edit and delete attachment when the user has the permissions(view, delete, edit) of documentation" do
+    wiki_content = WikiContent.create!(
+      :text => 'h1. Documentation',
+      :author_id => 2,
+      :page => WikiPage.create!(:title => 'Documentation',
+                                :wiki => Wiki.create!(:project_id => 1,
+                                                      :start_page => 'Wiki',
+                                                      :documentation_start_page => 'Documentation'),
+                                                      )
+    )
+    Attachment.find(10).update_attributes(:container_id => WikiPage.last().id, :container_type => 'WikiPage')
+
+    visit '/projects/ecookbook/documentation/documentation'
+
+    find("legend[class='icon icon-collapsed']").click
+
+    expect(page).to have_css("a[class='icon-only icon-edit']")
+    expect(page).to have_css("a[class='delete icon-only icon-del']")
+
+  end
+
 end


### PR DESCRIPTION
Mettre les attachable_options du documentation_pages avant d'afficher une documentation pour  pouvoir voir et modifier et supprimer les attachement.