### PR TITLE
Ticket 162124

### DIFF
--- a/app/controllers/documentation_controller.rb
+++ b/app/controllers/documentation_controller.rb
@@ -3,7 +3,6 @@ require_dependency 'wiki_controller'
 class DocumentationController < WikiController
 
   append_before_action :render_403_if_wiki, :only => [:show, :protect, :history, :diff, :annotate, :export, :add_attachment]
-  append_before_action :set_attachable_options, :only => [:show]
 
   # display a page (in editing mode if it doesn't exist)
   def show
@@ -227,12 +226,6 @@ class DocumentationController < WikiController
 
   def render_403_if_wiki
     return render_403 if @page&.persisted? && @page.wiki_page?
-  end
-
-  def set_attachable_options
-    @page.class.attachable_options[:view_permission] = "view_documentation_pages".to_sym
-    @page.class.attachable_options[:edit_permission] = "edit_documentation_pages".to_sym
-    @page.class.attachable_options[:delete_permission] = "edit_documentation_pages".to_sym
   end
 
 end

--- a/lib/redmine_second_wiki/wiki_controller_patch.rb
+++ b/lib/redmine_second_wiki/wiki_controller_patch.rb
@@ -3,6 +3,7 @@ require_dependency 'wiki_controller'
 class WikiController
 
   append_before_action :render_403_if_documentation, :only => [:show, :protect, :history, :diff, :annotate, :export, :add_attachment]
+  append_before_action :set_attachable_options, :only => [:show]
 
   def load_pages_for_index
     @pages = @wiki.pages.with_updated_on.
@@ -20,6 +21,12 @@ class WikiController
     if @page&.persisted? && controller_name != 'documentation' && @page.documentation_page?
       return render_403
     end
+  end
+
+  def set_attachable_options
+    @page.class.attachable_options[:view_permission] = "view_#{controller_name}_pages".to_sym
+    @page.class.attachable_options[:edit_permission] = "edit_#{controller_name}_pages".to_sym
+    @page.class.attachable_options[:delete_permission] = "edit_#{controller_name}_pages".to_sym
   end
 
 end

--- a/spec/system/documentation_spec.rb
+++ b/spec/system/documentation_spec.rb
@@ -118,4 +118,36 @@ content}
     expect(page).to have_css("a[class='delete icon-only icon-del']")
   end
 
+  it "shows both icons to edit and delete attachment when the user has the permissions(view, delete, edit) on wiki and no longer has permissions on the documentation" do
+
+    manager_role = Role.find(1)
+    [:view_wiki_pages,
+     :view_wiki_edits,
+     :export_wiki_pages,
+     :edit_wiki_pages,
+     :rename_wiki_pages,
+     :delete_wiki_pages,
+     :delete_wiki_pages_attachments,
+     :protect_wiki_pages,
+     :manage_wiki].each do |permission|
+      manager_role.add_permission!(permission)
+    end
+
+    # add a documentation
+    visit '/projects/ecookbook/documentation'
+    click_on 'Save'
+
+    # disable module of documentation
+    Project.find(1).disable_module!(:documentation)
+
+    visit '/projects/ecookbook/wiki'
+
+    expect(page).to have_current_path('/projects/ecookbook/wiki')
+
+    find("legend[class='icon icon-collapsed']").click
+
+    expect(page).to have_css("a[class='icon-only icon-edit']")
+    expect(page).to have_css("a[class='delete icon-only icon-del']")
+
+  end
 end


### PR DESCRIPTION
- Mettre set_attachable_options dans le contrôler Wiki Contrôler pour que l'user  ait les bonnes permissions sur wiki et documentation
- Créer le test pour assurer que l'user ait les bonnes permissions sur le wiki quand il a plus les permissions sur le document